### PR TITLE
[YIapi] make file extention case insensitive

### DIFF
--- a/qml/lib/YIapi.qml
+++ b/qml/lib/YIapi.qml
@@ -179,7 +179,7 @@ Item {
                     previewImage: '',
                     bytes: parseInt(values[0]),
                     date: new Date(values[1]),
-                    isVideo: fileName.indexOf('.MP4') > -1
+                    isVideo: fileName.toLowerCase().indexOf('.mp4') > -1
                 };
             }
 


### PR DESCRIPTION
please check if it does the job on the Yi 4K on my Discovery the file extension is lower case.
With this change it should work in any case as qml change the input to lower case. 